### PR TITLE
Posthog Visitor identification

### DIFF
--- a/packages/middleware/src/types.ts
+++ b/packages/middleware/src/types.ts
@@ -400,6 +400,13 @@ export type TformConfig = {
 export type TdynamicFormProps = {
   config: TformConfig
   onSuccess: (message: string, title: string) => void
+  onSuccessfulSubmit?: (payload: {
+    formData: Record<string, unknown>
+    formId: string
+    formTitle?: string
+    source?: string
+    meta?: Record<string, unknown>
+  }) => void | Promise<void>
   onCancel?: () => void
   className?: string
   defaultValues?: Record<string, any>

--- a/packages/ui/src/api/appointment/book-appointment.ts
+++ b/packages/ui/src/api/appointment/book-appointment.ts
@@ -2,6 +2,7 @@
 
 import { z } from "zod"
 import { TapiResponse } from "@repo/middleware/types"
+import { linkFrappeRecordByEmailToPostHog } from "@repo/ui/api/crm/posthog-link"
 
 // Function to verify reCAPTCHA token using Google's siteverify API
 async function fnVerifyRecaptcha(iToken: string): Promise<boolean> {
@@ -85,6 +86,8 @@ export async function bookAppointmentAction(
 
     // On success, return the booking confirmation
     const LdResult = await LdResponse.json()
+    await linkFrappeRecordByEmailToPostHog(contact.email)
+
     return {
       message: "Booking confirmed successfully",
       data: LdResult,

--- a/packages/ui/src/api/casestudy/create-lead.ts
+++ b/packages/ui/src/api/casestudy/create-lead.ts
@@ -1,6 +1,7 @@
 "use server"
 
 import { TleadApi } from "@repo/middleware/types"
+import { linkFrappeRecordToPostHog } from "@repo/ui/api/crm/posthog-link"
 
 // Verifies the Google reCAPTCHA token received from the client
 async function fnVerifyRecaptchaToken(
@@ -104,6 +105,11 @@ export async function fnLeadCreation(idLeadFormData: TleadApi) {
       }
 
       const LdCreateLeadResult = await LdCreateLeadResponse.json()
+      await linkFrappeRecordToPostHog(
+        "Lead",
+        LdCreateLeadResult.data?.name,
+        idLeadFormData.email,
+      )
 
       return {
         data: LdCreateLeadResult.data,
@@ -112,6 +118,12 @@ export async function fnLeadCreation(idLeadFormData: TleadApi) {
     }
 
     // Lead already exists then return existing lead
+    await linkFrappeRecordToPostHog(
+      "Lead",
+      LdLeadLookupResult.data[0]?.name,
+      idLeadFormData.email,
+    )
+
     return {
       data: LdLeadLookupResult.data[0],
       message: "exist",

--- a/packages/ui/src/api/contact/create-contact.ts
+++ b/packages/ui/src/api/contact/create-contact.ts
@@ -1,6 +1,7 @@
 "use server"
 
 import { TcontactApi } from "@repo/middleware/types"
+import { linkFrappeRecordToPostHog } from "@repo/ui/api/crm/posthog-link"
 
 // Function to verify reCAPTCHA token using Google's siteverify API
 async function fnVerifyRecaptcha(iToken: string): Promise<boolean> {
@@ -77,12 +78,23 @@ export async function ContactApi(idFormdata: TcontactApi) {
         redirect: "follow",
       })
       const LdPostContactResult = await LdPostContact.json()
+      await linkFrappeRecordToPostHog(
+        "Contact",
+        LdPostContactResult.data?.name,
+        idFormdata.formData.email,
+      )
 
       return {
         data: LdPostContactResult.data,
         message: "created",
       }
     } else {
+      await linkFrappeRecordToPostHog(
+        "Contact",
+        LdContactResult.data[0]?.name,
+        idFormdata.formData.email,
+      )
+
       // Contact already exists
       return {
         data: LdContactResult.data[0],

--- a/packages/ui/src/api/crm/posthog-link.ts
+++ b/packages/ui/src/api/crm/posthog-link.ts
@@ -1,0 +1,99 @@
+"use server"
+
+type TFrappeDoctype = "Contact" | "Lead"
+
+const fnNormalizePostHogDistinctId = (iEmail?: unknown) => {
+  if (typeof iEmail !== "string") return null
+
+  const LEmail = iEmail.trim().toLowerCase()
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(LEmail) ? LEmail : null
+}
+
+const fnGetCrmConfig = () => {
+  const LBaseUrl = process.env.SUBSCRIBE_URL
+  const LAuthorizationHeader = process.env.AUTH_BASE_64
+
+  if (!LBaseUrl || !LAuthorizationHeader) {
+    return null
+  }
+
+  return {
+    baseUrl: LBaseUrl,
+    headers: {
+      Authorization: LAuthorizationHeader,
+      "Content-Type": "application/json",
+      Cookie:
+        "full_name=Guest; sid=Guest; system_user=no; user_id=Guest; user_image=",
+    },
+  }
+}
+
+export async function linkFrappeRecordToPostHog(
+  iDoctype: TFrappeDoctype,
+  iRecordName: unknown,
+  iEmail: unknown,
+) {
+  const LDistinctId = fnNormalizePostHogDistinctId(iEmail)
+  const LRecordName = typeof iRecordName === "string" ? iRecordName : null
+  const LConfig = fnGetCrmConfig()
+
+  if (!LDistinctId || !LRecordName || !LConfig) return
+
+  try {
+    const LdResponse = await fetch(
+      `${LConfig.baseUrl}/api/resource/${iDoctype}/${encodeURIComponent(LRecordName)}`,
+      {
+        method: "PUT",
+        headers: LConfig.headers,
+        body: JSON.stringify({ custom_posthog_distinct_id: LDistinctId }),
+      },
+    )
+
+    if (!LdResponse.ok) {
+      console.error(
+        `PostHog CRM link failed for ${iDoctype} ${LRecordName}:`,
+        await LdResponse.text(),
+      )
+    }
+  } catch (iError) {
+    console.error(`PostHog CRM link failed for ${iDoctype}:`, iError)
+  }
+}
+
+export async function linkFrappeRecordByEmailToPostHog(iEmail: unknown) {
+  const LDistinctId = fnNormalizePostHogDistinctId(iEmail)
+  const LConfig = fnGetCrmConfig()
+
+  if (!LDistinctId || !LConfig) return
+
+  for (const LDoctype of ["Contact", "Lead"] as const) {
+    try {
+      const LEmailField = LDoctype === "Contact" ? "email_id" : "email_id"
+      const LdLookupResponse = await fetch(
+        `${LConfig.baseUrl}/api/resource/${LDoctype}?fields=["name"]&filters=[["${LEmailField}","=","${LDistinctId}"]]`,
+        {
+          method: "GET",
+          headers: LConfig.headers,
+        },
+      )
+
+      if (!LdLookupResponse.ok) {
+        console.error(
+          `PostHog CRM lookup failed for ${LDoctype}:`,
+          await LdLookupResponse.text(),
+        )
+        continue
+      }
+
+      const LdLookupResult = await LdLookupResponse.json()
+      const LRecordName = LdLookupResult?.data?.[0]?.name
+
+      if (LRecordName) {
+        await linkFrappeRecordToPostHog(LDoctype, LRecordName, LDistinctId)
+        return
+      }
+    } catch (iError) {
+      console.error(`PostHog CRM lookup failed for ${LDoctype}:`, iError)
+    }
+  }
+}

--- a/packages/ui/src/api/newsletter/create-subscription.ts
+++ b/packages/ui/src/api/newsletter/create-subscription.ts
@@ -2,6 +2,18 @@
 
 // Zod is a TypeScript-first schema validation library recommended by Next.js
 import { z } from "zod"
+import { linkFrappeRecordByEmailToPostHog } from "@repo/ui/api/crm/posthog-link"
+
+export type TnewsletterSubscriptionStatus =
+  | "subscribed"
+  | "already_subscribed"
+  | "error"
+
+export type TnewsletterSubscriptionState = {
+  message: string
+  email?: string
+  status: TnewsletterSubscriptionStatus
+}
 
 // Define expected structure and constraints for form data
 const LdSchema = z.object({
@@ -9,9 +21,9 @@ const LdSchema = z.object({
 })
 
 export async function subscribeNewsletter(
-  idPrevState: { message: string },
+  idPrevState: { message: string; status?: TnewsletterSubscriptionStatus },
   idFormData: FormData,
-): Promise<{ message: string }> {
+): Promise<TnewsletterSubscriptionState> {
   //headers for API requests
   const LdHeaders = {
     Authorization: `${process.env.AUTH_BASE_64}`,
@@ -29,6 +41,7 @@ export async function subscribeNewsletter(
     return {
       message:
         LdParsed.error.flatten().fieldErrors.email?.[0] || "Invalid input",
+      status: "error",
     }
   }
 
@@ -49,7 +62,12 @@ export async function subscribeNewsletter(
 
     // If email exists in the "Website" group, inform the user instead of trying to subscribe again
     if (LdCheckData?.data?.length > 0) {
-      return { message: "You're already subscribed!" }
+      await linkFrappeRecordByEmailToPostHog(LEmail)
+      return {
+        message: "You're already subscribed!",
+        email: LEmail,
+        status: "already_subscribed",
+      }
     }
 
     // If the email isn't already subscribed, submit it to the backend via a POST request
@@ -65,6 +83,7 @@ export async function subscribeNewsletter(
     if (LdSubscribe.status === 429) {
       return {
         message: "Too many requests. Please wait a moment before trying again.",
+        status: "error",
       }
     }
 
@@ -73,10 +92,17 @@ export async function subscribeNewsletter(
       throw new Error(await LdSubscribe.text())
     }
 
-    return { message: "Please check your inbox!" }
+    await linkFrappeRecordByEmailToPostHog(LEmail)
+
+    return {
+      message: "Please check your inbox!",
+      email: LEmail,
+      status: "subscribed",
+    }
   } catch (err: any) {
     return {
       message: err.message || "An error occurred, please try again later.",
+      status: "error",
     }
   }
 }

--- a/packages/ui/src/components/footer.tsx
+++ b/packages/ui/src/components/footer.tsx
@@ -1,11 +1,11 @@
 "use client"
 
 import Link from "next/link"
-import { type ReactElement, useActionState } from "react"
+import { type ReactElement, useActionState, useEffect } from "react"
 import { Button } from "@repo/ui/components/ui/button"
 import { Input } from "@repo/ui/components/ui/input"
 import { Twitter, Linkedin, Mail, Phone, MapPin, Youtube } from "lucide-react"
-import { subscribeNewsletter } from "@repo/ui/api/newsletter/create-subscription"
+import { subscribeNewsletter, type TnewsletterSubscriptionState } from "@repo/ui/api/newsletter/create-subscription"
 import { TfooterTarget } from "@repo/middleware/types";
 
 // Map of icon names to their components
@@ -21,8 +21,25 @@ const iconMap = {
 type IconKey = keyof typeof iconMap
 
 export default function Footer({ idFooter }: { idFooter: TfooterTarget }): ReactElement {
-  const LdInitialState = { message: "", }
+  const LdInitialState: TnewsletterSubscriptionState = { message: "", status: "error" }
   const [state, formAction, pending] = useActionState(subscribeNewsletter, LdInitialState)
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      !state.email ||
+      !["subscribed", "already_subscribed"].includes(state.status)
+    ) {
+      return
+    }
+
+    window.dispatchEvent(
+      new CustomEvent("newsletter_subscribed", {
+        detail: { email: state.email, status: state.status },
+      }),
+    )
+  }, [state.email, state.status])
+
   return (
     <footer className="bg-muted/80 pt-16 pb-8">
       <div className="container mx-auto px-4">

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -30,6 +30,7 @@ import { fetchTimezones } from "@repo/ui/api/appointment/fetch-timezone"
 import { fetchTimeSlots } from "@repo/ui/api/appointment/fetch-timeslot"
 import { bookAppointmentAction } from "@repo/ui/api/appointment/book-appointment"
 import { subscribeNewsletter } from "@repo/ui/api/newsletter/create-subscription"
+import { linkFrappeRecordByEmailToPostHog } from "@repo/ui/api/crm/posthog-link"
 import { sendCommunicationAction } from "@repo/ui/api/contact/fetch-contact"
 import { UpdateEventParticipant } from "@repo/ui/api/event/create-participant"
 
@@ -206,6 +207,8 @@ export async function fnSubmitContact(idFormData: any, iRecaptchaToken: string) 
             return { error: LdResponse.error }
         }
 
+        await linkFrappeRecordByEmailToPostHog(idFormData.email)
+
         // Return success response with any provided message and data
         return {
             data: LdResponse.data,
@@ -330,6 +333,7 @@ export async function fnDownload(
 function InnerSectionForm({
     config,
     onSuccess,
+    onSuccessfulSubmit,
     className = "",
     defaultValues,
     hideCardHeader = false,
@@ -344,6 +348,11 @@ function InnerSectionForm({
     const [IsSubmitting, fnSetIsSubmitting] = useState(false)
     const FormRef = useRef<HTMLDivElement>(null)
     const { executeRecaptcha } = useReCaptcha()
+
+    const fnSanitizeFormData = (idFormData: Record<string, unknown>) =>
+        Object.fromEntries(
+            Object.entries(idFormData).filter(([iKey]) => !["recaptchaToken", "timeSlot"].includes(iKey))
+        )
 
     // Sets up default values for all possible form fields, overridden by any provided values
     const LdInitialValues = {
@@ -465,6 +474,16 @@ function InnerSectionForm({
             if (LdResponse.error) {
                 throw new Error(LdResponse.error)
             }
+
+            await onSuccessfulSubmit?.({
+                formData: fnSanitizeFormData(idFormData),
+                formId: config.formId,
+                formTitle: config.title,
+                meta: {
+                    case_study_name: pdfData?.caseStudies?.[0]?.name,
+                    webinar_title: data?.title,
+                },
+            })
 
             LdForm.reset(LdInitialValues)
             onSuccess(config.successMessage, config.successTitle)


### PR DESCRIPTION
Posthog Visitor identification

**Summary**
- Adds app-only PostHog identify helper using normalized lowercase email as distinct_id.
- Wires shared form submissions, direct contact/booking forms, case study downloads, and footer newsletter conversions into identify.
- Adds client newsletter listener while leaving existing PostHog init and /ingest proxy unchanged.
