### PR TITLE
story-US-2026-1231 : WEB - Bug Posthog - Subscription and full Testing

### DIFF
--- a/packages/ui/src/api/newsletter/create-subscription.ts
+++ b/packages/ui/src/api/newsletter/create-subscription.ts
@@ -15,28 +15,9 @@ export type TnewsletterSubscriptionState = {
   status: TnewsletterSubscriptionStatus
 }
 
-// Function to verify reCAPTCHA token using Google's siteverify API
-async function fnVerifyRecaptcha(iToken: string): Promise<boolean> {
-  const LSecretKey = process.env.RECAPTCHA_SECRET_KEY
-  const LRecaptchaUrl = `https://www.google.com/recaptcha/api/siteverify?secret=${LSecretKey}&response=${iToken}`
-
-  try {
-    const LdResponse = await fetch(LRecaptchaUrl, { method: "POST" })
-    const LdData = await LdResponse.json()
-
-    // Return true only if verification is successful and the score is above threshold
-    return LdData.success && LdData.score >= 0.5
-    
-  } catch (error) {
-    console.error("reCAPTCHA verification error:", error)
-    return false
-  }
-}
-
 // Define expected structure and constraints for form data
 const LdSchema = z.object({
   email: z.string().email("Please enter a valid email"),
-  recaptchaToken: z.string(),
 })
 
 export async function subscribeNewsletter(
@@ -53,17 +34,13 @@ export async function subscribeNewsletter(
   // Validate form input early to fail fast and give user feedback before hitting the backend
   const LdParsed = LdSchema.safeParse({
     email: idFormData.get("email"),
-    recaptchaToken: idFormData.get("recaptchaToken"),
   })
 
   // If validation fails, return a user-friendly message without making any API requests
   if (!LdParsed.success) {
-    const LdErrors = LdParsed.error.flatten().fieldErrors
     return {
       message:
-        LdErrors.email?.[0] ??
-        LdErrors.recaptchaToken?.[0] ??
-        "Invalid input",
+        LdParsed.error.flatten().fieldErrors.email?.[0] || "Invalid input",
       status: "error",
     }
   }
@@ -73,13 +50,6 @@ export async function subscribeNewsletter(
 
   // Disables TLS verification for local development
   // process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"
-
-  // Verify if the form submission is made by a human
-  const LIsHuman = await fnVerifyRecaptcha(LdParsed.data.recaptchaToken,)
-  if (!LIsHuman) {
-    return {  message: "reCAPTCHA verification failed",
-      status: "error",}
-  }
 
   try {
     // First check: is this email already subscribed? Prevents duplicate entries and unnecessary API calls

--- a/packages/ui/src/api/newsletter/subscription-captcha.ts
+++ b/packages/ui/src/api/newsletter/subscription-captcha.ts
@@ -1,0 +1,65 @@
+"use server"
+
+import z from "zod"
+import { subscribeNewsletter, TnewsletterSubscriptionState, TnewsletterSubscriptionStatus } from "./create-subscription"
+
+const LdCaptchaSchema = z.object({
+    email: z.string().email("Please enter a valid email"),
+    recaptchaToken: z.string(),
+  })
+  
+  // Function to verify reCAPTCHA token using Google's siteverify API
+async function fnVerifyRecaptcha(iToken: string): Promise<boolean> {
+  const LSecretKey = process.env.RECAPTCHA_SECRET_KEY
+  const LRecaptchaUrl = `https://www.google.com/recaptcha/api/siteverify?secret=${LSecretKey}&response=${iToken}`
+
+  try {
+    const LdResponse = await fetch(LRecaptchaUrl, { method: "POST" })
+    const LdData = await LdResponse.json()
+    // Return true only if verification is successful and the score is above threshold
+    return LdData.success && LdData.score >= 0.5
+    
+  } catch (error) {
+    console.error("reCAPTCHA verification error:", error)
+    return false
+  }
+}
+
+  export async function fnSubscribewithCaptcha(
+    idPrevState: {
+      message: string
+      status?: TnewsletterSubscriptionStatus
+    },
+    idFormData: FormData,
+  ): Promise<TnewsletterSubscriptionState> {
+    const LdParsed = LdCaptchaSchema.safeParse({
+      email: idFormData.get("email"),
+      recaptchaToken: idFormData.get("recaptchaToken"),
+    })
+  
+    if (!LdParsed.success) {
+      const LdErrors = LdParsed.error.flatten().fieldErrors
+  
+      return {
+        message:
+          LdErrors.email?.[0] ??
+          LdErrors.recaptchaToken?.[0] ??
+          "Invalid input",
+        status: "error",
+      }
+    }
+    // Recaptcha Token
+    const LIsHuman = await fnVerifyRecaptcha(
+      LdParsed.data.recaptchaToken,
+    )
+  
+    if (!LIsHuman) {
+      return {
+        message: "reCAPTCHA verification failed",
+        status: "error",
+      }
+    }
+  
+    // re-use existing newsletter logic
+    return subscribeNewsletter(idPrevState, idFormData)
+  }

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -84,7 +84,6 @@ export async function fnSubmitWebinar(idFormData: any, idData: TtrendCardProps, 
         if (idFormData.newsletter) {
             const LdNewFormData = new FormData();
             LdNewFormData.append("email", idFormData.email);
-            LdNewFormData.append("recaptchaToken", iRecaptchaToken);
             await subscribeNewsletter({ message: "" }, LdNewFormData);
         }
 
@@ -148,7 +147,6 @@ export async function fnSubmitAppointmentBooking(idFormData: any, iRecaptchaToke
         if (idFormData.newsletter) {
             const LdNewFormData = new FormData()
             LdNewFormData.append("email", idFormData.email)
-            LdNewFormData.append("recaptchaToken", iRecaptchaToken);
             await subscribeNewsletter({ message: "" }, LdNewFormData)
         }
 
@@ -201,7 +199,6 @@ export async function fnSubmitContact(idFormData: any, iRecaptchaToken: string) 
         if (idFormData.newsletter) {
             const LdNewFormData = new FormData()
             LdNewFormData.append("email", idFormData.email)
-            LdNewFormData.append("recaptchaToken", iRecaptchaToken);
             await subscribeNewsletter({ message: "" }, LdNewFormData)
         }
 
@@ -269,7 +266,6 @@ export async function fnDownload(
         if (idFormData.newsletter) {
             // Prepare a FormData object with the user's email
             const LdNewFormData = new FormData();
-            LdNewFormData.append("recaptchaToken", iRecaptchaToken);
             LdNewFormData.append("email", idFormData.email);
 
             // Subscribe the user to the newsletter

--- a/packages/ui/src/components/subscription.tsx
+++ b/packages/ui/src/components/subscription.tsx
@@ -2,14 +2,12 @@
 
 import { Button } from "@repo/ui/components/ui/button";
 import { Input } from "@repo/ui/components/ui/input";
-import {
-  subscribeNewsletter,
-  type TnewsletterSubscriptionState,
-} from "@repo/ui/api/newsletter/create-subscription";
 import { TNewsletterSubscriptionProps } from "@repo/middleware/types";
 import posthog from "posthog-js";
 import { useEffect, useState } from "react";
 import { ReCaptchaProvider, useReCaptcha } from "next-recaptcha-v3"
+import { fnSubscribewithCaptcha } from "@repo/ui/api/newsletter/subscription-captcha";
+import { TnewsletterSubscriptionState } from "@repo/ui/api/newsletter/create-subscription";
 
 const LdVariants = {
   sm: {
@@ -111,7 +109,7 @@ export function NewsletterSubscriptionForm({
         });
       }
       // subscription apis
-      const LdResult = await subscribeNewsletter(
+      const LdResult = await fnSubscribewithCaptcha(
         { message: "", status: "error" },
         LdFormData,
       );


### PR DESCRIPTION
**Bug**
The same reCAPTCHA token was being used for both the newsletter subscription API and other form APIs (such as Booking and Contact). Since Google reCAPTCHA tokens are single-use, the subscription request was treated as a duplicate submission and its execution was blocked.

**Fix**
The newsletter subscription reCAPTCHA validation is now handled only within the Footer subscription form, where the subscription flow is initiated directly.

For Booking, Contact, and other forms where newsletter subscription is optional, the subscription request no longer performs a separate reCAPTCHA validation. Instead, only the primary form APIs (Booking, Contact, etc.) are validated using reCAPTCHA, preventing token reuse and ensuring successful form submission.

**Changed Object:**
- packages/ui/src/api/newsletter/create-subscription.ts
- packages/ui/src/api/newsletter/subscription-captcha.ts
- packages/ui/src/components/form.tsx
- packages/ui/src/components/subscription.tsx